### PR TITLE
Add support for different architectures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,15 @@ runs:
         echo "Not Lowercasing OS Type ${os}"
       esac
 
+      # Map runner.arch to release asset arch
+      arch="${{ runner.arch }}"
+      case "$arch" in
+        X64)   arch="amd64" ;;
+        ARM64) arch="arm64" ;;
+        *)     echo "Unsupported arch: $arch"; exit 1 ;;
+      esac
+
       if [[ ! -z ${tag} ]]; then
-        echo "Installing docker-credential-gcr @ ${tag} for ${os}"
-        curl -fsL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${tag}/docker-credential-gcr_${os}_amd64-${tag:1}.tar.gz | sudo tar xzf - -C /usr/local/bin docker-credential-gcr
+        echo "Installing docker-credential-gcr @ ${tag} for ${os}/${arch}"
+        curl -fsL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${tag}/docker-credential-gcr_${os}_${arch}-${tag:1}.tar.gz | sudo tar xzf - -C /usr/local/bin docker-credential-gcr
       fi


### PR DESCRIPTION
While using this action, we realised that it couldn't run for our self hosted arm64 runners, due to exec format errors.

We need to make sure that we can download both arm64 and amd64 binaries based on the `runner.arch` variable provided by GitHub.

[Example release](https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/tag/v2.1.29), with different binaries in place.